### PR TITLE
Added postal code of Garching.

### DIFF
--- a/2014/csipaper/nexus14aip.tex
+++ b/2014/csipaper/nexus14aip.tex
@@ -88,10 +88,10 @@ rsi,
 \affiliation{Swiss Light Source, Paul Scherrer Institute, 5232 Villigen-PSI, Switzerland}
 
 \author{Eugen Wintersberger}
-\affiliation{Deutsches Elektronen-Synchrotron DESY,D-22607 Hamburg,Germany}
+\affiliation{Deutsches Elektronen-Synchrotron DESY, 22607 Hamburg, Germany}
 
 \author{Joachim Wuttke}
-\affiliation{Forschungszentrum J\"ulich, JCNS at MLZ, Garching, Germany}
+\affiliation{Forschungszentrum J\"ulich, JCNS at MLZ, 85747 Garching, Germany}
 
 
 \collaboration{NeXus International Advisory Committee}


### PR DESCRIPTION
@Eugen: to the best of my knowledge, prefix "D-" is declared obsolete by Deutsche Post.
